### PR TITLE
Update language-configuration.json

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,18 +1,11 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        "lineComment": "!"
     },
-    // symbols used as brackets
-    "brackets": [
-        ["{", "}"],
-        ["[", "]"],
-        ["(", ")"]
-    ],
     // symbols that are auto closed when typing
     "autoClosingPairs": [
+        ["^C", "^C"],
         ["{", "}"],
         ["[", "]"],
         ["(", ")"],
@@ -21,6 +14,7 @@
     ],
     // symbols that that can be used to surround a selection
     "surroundingPairs": [
+        ["^C", "^C"],
         ["{", "}"],
         ["[", "]"],
         ["(", ")"],


### PR DESCRIPTION
Hi,

Please check this PR:
* IOS comment lines begin with "!"
* IOS language does not support block comment nor bracket
* ^C is a pair used for banners (note: the surroundingPairs part does not work, but I add it for consistency)