### PR TITLE
Update cisco.tmLanguage

### DIFF
--- a/syntaxes/cisco.tmLanguage
+++ b/syntaxes/cisco.tmLanguage
@@ -4,8 +4,6 @@
 <dict>
 	<key>fileTypes</key>
 	<array>
-		<string>cfg</string>
-		<string>txt</string>
 		<string>ios</string>
 	</array>
 	<key>foldingStartMarker</key>


### PR DESCRIPTION
Remove `.txt` and `.cfg` from fileTypes to prevent overriding default behaviour on generic files