### PR TITLE
Modified 'any' highlight

### DIFF
--- a/syntaxes/cisco.tmLanguage
+++ b/syntaxes/cisco.tmLanguage
@@ -34,7 +34,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>any</string>
+			<string>any[46]? </string>
 			<key>name</key>
 			<string>string.unquoted.cisco</string>
 		</dict>


### PR DESCRIPTION
Modified 'any' highlight to include any, any4 and any6.  Also added a space to exclude terms like anyconnect.