### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Cisco Syntax Highlighting for [Visual Studio Code](https://code.visualstudio.com/).
 
+Save files with the file extension ".ios" to enable syntax highlighting.
+
 Converted from [here](https://github.com/tunnelsup/sublime-cisco-syntax).
 
 Source can be found [here](https://github.com/woodjme/vscode-cisco-syntax).


### PR DESCRIPTION
added the necessary file extension to the readme so enabling the syntax highlighting for your Cisco config is more obvious to noobs like myself. =]