### PR TITLE
Add syntax support for 25G and 40G interfaces

### DIFF
--- a/syntaxes/cisco.tmLanguage
+++ b/syntaxes/cisco.tmLanguage
@@ -133,7 +133,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b((Fast|Gigabit|TenGigabit)?Ethernet|Dialer|Dot11Radio|ATM|BRI|Tunnel(Group-)?Async|BVI|[Ll]oopback|Null|[Pp]ort-channel|Virtual-(Access|Dot11Radio|PPP|Template)|TenGigE|HundredGigE|tunnel-ip|Bundle-Ether|MgmtEth0)</string>
+			<string>\b((Fast|Gigabit|TenGigabit|FortyGigabit)?Ethernet|Dialer|Dot11Radio|ATM|BRI|Tunnel(Group-)?Async|BVI|[Ll]oopback|Null|[Pp]ort-channel|Virtual-(Access|Dot11Radio|PPP|Template)|TenGigE|TwentyFiveGigE|HundredGigE|tunnel-ip|Bundle-Ether|MgmtEth0)</string>
 			<key>name</key>
 			<string>constant.language.cisco</string>
 		</dict>


### PR DESCRIPTION
Add in support for 25G (TwentyFiveGigE) and 40G (FortyGigabitEthernet) interfaces

A Cisco configuration guide is available for reference [here](https://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst9500/software/release/16-10/configuration_guide/ha/b_1610_ha_9500_cg/configuring_cisco_stackwise_virtual.html).